### PR TITLE
feat(resource): add onUnauthorized hook for automatic 401 handling

### DIFF
--- a/src/runtime/defineResource/index.ts
+++ b/src/runtime/defineResource/index.ts
@@ -1,4 +1,4 @@
-import { useNuxtApp } from "nuxt/app";
+import { navigateTo, useNuxtApp } from "nuxt/app";
 
 import search from "../methods/search";
 import mutate from "../methods/mutate";
@@ -23,6 +23,12 @@ const combineHooks = (globalHook, specificHook) => {
 		if (typeof specificHook === "function") await specificHook(arg);
 	};
 }
+
+let isUnauthorizedHandled = false;
+
+export const resetUnauthorizedState = (): void => {
+	isUnauthorizedHandled = false;
+};
 
 
 const joinUrl = (base: string, path: string) =>
@@ -53,14 +59,26 @@ const defineResource = <T>(resourceName: string, preset: IResourcePreset<T> = {}
 
 	const resourceUrl = joinUrl(globalFetchOptions?.baseURL ?? "", `/${resourceName}`);
 
+	const { onUnauthorized, ...fetchOptionsWithoutUnauthorized } = globalFetchOptions ?? {};
+
+	const onResponseErrorWithUnauthorized = onUnauthorized
+		? combineHooks(({ response }) => {
+			if (response?.status === 401 && !isUnauthorizedHandled) {
+				isUnauthorizedHandled = true;
+				if (typeof onUnauthorized === 'function') onUnauthorized();
+				else navigateTo(onUnauthorized);
+			}
+		}, globalFetchOptions?.onResponseError)
+		: globalFetchOptions?.onResponseError;
+
 	// @ts-ignore
 	const api = $fetch.create({
-		...globalFetchOptions,
+		...fetchOptionsWithoutUnauthorized,
 		baseURL: resourceUrl,
 		onRequest: combineHooks(globalFetchOptions?.onRequest, presets.onRequest),
 		onRequestError: combineHooks(globalFetchOptions?.onRequestError, presets.onRequestError),
 		onResponse: combineHooks(globalFetchOptions?.onResponse, presets.onResponse),
-		onResponseError: combineHooks(globalFetchOptions?.onResponseError, presets.onResponseError),
+		onResponseError: combineHooks(onResponseErrorWithUnauthorized, presets.onResponseError),
 	})
 
 

--- a/src/runtime/types/fetchOptions.d.ts
+++ b/src/runtime/types/fetchOptions.d.ts
@@ -23,6 +23,7 @@ interface FetchOptions<R extends ResponseType = ResponseType, T = any> extends O
 	 * Only supported older Node.js versions using node-fetch-native polyfill.
 	 */
 	agent?: unknown;
+	onUnauthorized?: string | (() => void);
 	/** timeout in milliseconds */
 	timeout?: number;
 	retry?: number | false;

--- a/tests/defineResource.nuxt.test.ts
+++ b/tests/defineResource.nuxt.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 
-// On mock les méthodes utilisées dans defineResource
+// Mock methods used in defineResource
 vi.mock("../src/runtime/methods/details", () => ({
 	default: vi.fn(() => Promise.resolve("details-called")),
 }));
@@ -18,12 +18,19 @@ vi.mock("../src/runtime/methods/delete", () => ({
 	default: vi.fn(() => Promise.resolve("remove-called")),
 }));
 
-// Mock de $fetch.create
+// Mock $fetch.create
+let capturedCreateOptions: Record<string, any> = {};
 vi.mock("ofetch", () => ({
-	$fetch: { create: () => "api-client" },
+	$fetch: {
+		create: (options: Record<string, any>) => {
+			capturedCreateOptions = options;
+			return "api-client";
+		},
+	},
 }));
 
-// Mock de useNuxtApp
+// Mock useNuxtApp + navigateTo
+const mockNavigateTo = vi.fn();
 const mockGetGlobalFetchOptions = vi.fn(() => ({
 	baseURL: "https://api.test",
 	onRequest: undefined,
@@ -37,14 +44,16 @@ vi.mock("nuxt/app", () => ({
 			getGlobalFetchOptions: mockGetGlobalFetchOptions,
 		},
 	}),
+	navigateTo: (...args: unknown[]) => mockNavigateTo(...args),
 }));
 
-import defineResource from "../src/runtime/defineResource/index";
+import defineResource, { resetUnauthorizedState } from "../src/runtime/defineResource/index";
 
 
 describe("defineResource", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		resetUnauthorizedState();
 	});
 	it("should return all methods", () => {
 		const resource = defineResource("products")();
@@ -55,15 +64,72 @@ describe("defineResource", () => {
 		expect(resource).toHaveProperty("remove");
 	});
 
-	it("configure et appelle details correctement", async () => {
+	it("should configure and call details correctly", async () => {
 		const resource = defineResource("products")();
 		const result = await resource.details();
 		expect(result).toBe("details-called");
 	});
 
-	it("configure et appelle search correctement", async () => {
+	it("should configure and call search correctly", async () => {
 		const resource = defineResource("products")();
 		const result = await resource.search();
 		expect(result).toBe("search-called");
+	});
+
+	it("should call onUnauthorized when response status is 401", async () => {
+		const onUnauthorized = vi.fn();
+		mockGetGlobalFetchOptions.mockReturnValueOnce({
+			baseURL: "https://api.test",
+			onUnauthorized,
+		});
+
+		defineResource("products")();
+
+		await capturedCreateOptions.onResponseError({ response: { status: 401 } });
+
+		expect(onUnauthorized).toHaveBeenCalledOnce();
+	});
+
+	it("should call navigateTo when onUnauthorized is a string and response status is 401", async () => {
+		mockGetGlobalFetchOptions.mockReturnValueOnce({
+			baseURL: "https://api.test",
+			onUnauthorized: "/logout",
+		});
+
+		defineResource("products")();
+
+		await capturedCreateOptions.onResponseError({ response: { status: 401 } });
+
+		expect(mockNavigateTo).toHaveBeenCalledWith("/logout");
+	});
+
+	it("should not call onUnauthorized when response status is not 401", async () => {
+		const onUnauthorized = vi.fn();
+		mockGetGlobalFetchOptions.mockReturnValueOnce({
+			baseURL: "https://api.test",
+			onUnauthorized,
+		});
+
+		defineResource("products")();
+
+		await capturedCreateOptions.onResponseError({ response: { status: 403 } });
+
+		expect(onUnauthorized).not.toHaveBeenCalled();
+	});
+
+	it("should call onUnauthorized only once on multiple 401 responses", async () => {
+		const onUnauthorized = vi.fn();
+		mockGetGlobalFetchOptions.mockReturnValueOnce({
+			baseURL: "https://api.test",
+			onUnauthorized,
+		});
+
+		defineResource("products")();
+
+		await capturedCreateOptions.onResponseError({ response: { status: 401 } });
+		await capturedCreateOptions.onResponseError({ response: { status: 401 } });
+		await capturedCreateOptions.onResponseError({ response: { status: 401 } });
+
+		expect(onUnauthorized).toHaveBeenCalledOnce();
 	});
 });


### PR DESCRIPTION
Support string (navigateTo) or callback to handle unauthorized responses. Includes a guard to prevent multiple calls on parallel 401 responses.